### PR TITLE
Fix #11

### DIFF
--- a/app/routes/search/submissions.js
+++ b/app/routes/search/submissions.js
@@ -28,7 +28,7 @@ export default class SearchSubmissionsRoute extends Route {
     this.filter = params;
     this.lastParams.stageLive(params);
 
-    if (this.lastParams.anyFieldChanged(Object.keys(params).filter(key => key !== 'page'))) {
+    if (this.lastParams.hasBase && this.lastParams.anyFieldChanged(Object.keys(params).filter(key => key !== 'page'))) {
       params.page = 0;
     }
 


### PR DESCRIPTION
If there is no base yet (e.g. on page refresh), all fields will always be changed, but we want to respect the page parameter anyway.