### PR TITLE
Allow users to load more search results

### DIFF
--- a/app/components/filter/administrative-unit-select.hbs
+++ b/app/components/filter/administrative-unit-select.hbs
@@ -8,6 +8,13 @@
           @loadingMessage="Aan het laden..."
           @selected={{this.selected}}
           @onChange={{this.changeSelected}}
+          @optionsComponent={{component
+            "infinite-select/options"
+            canLoadMore=this.searchData.canLoadMoreSearchResults
+            loadMore=(perform this.loadMoreSearchResults)
+            isLoadingMore=this.loadMoreSearchResults.isRunning
+          }}
+          @registerAPI={{this.registerAPI}}
           @allowClear={{true}} as |bestuurseenheid|>
     {{bestuurseenheid.naam}} ({{bestuurseenheid.classificatie.label}})
   </PowerSelectMultiple>

--- a/app/components/infinite-select/options.hbs
+++ b/app/components/infinite-select/options.hbs
@@ -1,0 +1,29 @@
+<div class="infinite-select-options">
+  <PowerSelect::Options
+    @loadingMessage={{@loadingMessage}}
+    @select={{@select}}
+    @options={{@options}}
+    @groupIndex=""
+    @optionsComponent={{@optionsComponent}}
+    @extra={{@extra}}
+    @highlightOnHover={{@highlightOnHover}}
+    @groupComponent={{@groupComponent}}
+    ...attributes
+    as |option select|
+  >
+    {{yield option select}}
+  </PowerSelect::Options>
+  {{#if @canLoadMore}}
+    <div class="au-o-box au-o-box--tiny">
+      <AuButton
+        @skin="secondary"
+        @width="block"
+        @loading={{if @isLoadingMore "true"}}
+        @disabled={{if @isLoadingMore "true"}}
+        {{on "click" @loadMore}}
+      >
+        Meer bestuurseenheden laden
+      </AuButton>
+    </div>
+  {{/if}}
+</div>

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -99,3 +99,19 @@ td:focus {
 
   }
 }
+
+// "InfiniteSelect" component (this component should be made more generic and moved somewhere reusable)
+.infinite-select-options {
+  // Copied from ember-appuniversum: https://github.com/appuniversum/ember-appuniversum/blob/09fbccfa34190ab9552f42572d783d35e6925ad6/app/styles/ember-appuniversum/_p-ember-power-select.scss#L421-L424
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  @if unitless($ember-power-select-line-height) {
+    max-height: #{$ember-power-select-number-of-visible-options * $ember-power-select-line-height}em;
+  } @else {
+    max-height: $ember-power-select-number-of-visible-options * $ember-power-select-line-height;
+  }
+
+  .ember-power-select-options {
+    max-height: none;
+  }
+}


### PR DESCRIPTION
The search results are paginated by the server. Before this change not all options would be displayed and there was no option to load more. Some users couldn't find the option they needed and making the search term more specific isn't always possible.

This adds an extra button which users can click to manually load more search results.

This mimics the implementation in leidinggevenden DB: https://github.com/lblod/frontend-leidinggevenden-databank/pull/8

I wanted to look into a more generic solution but ran out of time due to other things popping up, so I simply reused the implementation for now. We probably want a more generic solution in Appuniversum. Something that could also keep loading the "preloaded" data.

![image](https://user-images.githubusercontent.com/3533236/194352002-0f5b43e7-57d5-4f3a-aaba-7503d110cd9e.png)
