### PR TITLE
Fix all remaining deprecations

### DIFF
--- a/app/components/search-queries/config-form.hbs
+++ b/app/components/search-queries/config-form.hbs
@@ -1,5 +1,5 @@
-<AuToolbar @size="medium" @skin="tint" @border="bottom">
-  <AuToolbarGroup>
+<AuToolbar @size="medium" @skin="tint" @border="bottom" as |Group|>
+  <Group>
     <ul class="au-c-list-horizontal">
       <li class="au-c-list-horizontal__item">
         <AuLink @route="search.submissions" class="au-c-button au-c-button--tertiary" type="button">
@@ -14,15 +14,15 @@
         <strong>Toezicht ABB - {{if this.isNewForm "Nieuwe" "Bewerk"}} zoekopdracht</strong>
       </li>
     </ul>
-  </AuToolbarGroup>
+  </Group>
 </AuToolbar>
 
-<AuToolbar @size="large" @border="bottom">
-  <AuToolbarGroup>
+<AuToolbar @size="large" @border="bottom" as |Group|>
+  <Group>
     <AuHeading @level="1" @skin="2">
       {{if this.isNewForm "Nieuwe" "Bewerk"}} zoekopdracht
     </AuHeading>
-  </AuToolbarGroup>
+  </Group>
 </AuToolbar>
 
 <div class="au-c-main-container__content au-c-main-container__content--scroll">
@@ -52,8 +52,8 @@
     {{/if}}
   </div>
 </div>
-<AuToolbar @size="large" @border="top">
-  <AuToolbarGroup>
+<AuToolbar @size="large" @border="top" as |Group|>
+  <Group>
     <AuButtonGroup>
       <AuButton @disabled={{if (or this.init.isRunning this.isFormEmpty) "true"}}
                 @loading={{if this.save.isRunning "true"}}
@@ -70,7 +70,7 @@
       {{/unless}}
       <AuButton @skin="tertiary" {{on "click" this.back}}>Annuleer</AuButton>
     </AuButtonGroup>
-  </AuToolbarGroup>
+  </Group>
   {{#unless this.isNewForm}}
     <AuButton @disabled={{if this.init.isRunning "true"}}
               @loading={{if this.remove.isRunning "true"}}

--- a/app/components/search-queries/config-form.hbs
+++ b/app/components/search-queries/config-form.hbs
@@ -32,10 +32,10 @@
       <span class="au-u-hidden-visually">Aan het laden</span>
     {{else}}
       {{#if this.error}}
-        <AuAlert @alertIcon="cross"
-                 @alertTitle="Oeps! Dit is genant ..."
-                 @alertskin={{"error"}}
-                 @closable="true"
+        <AuAlert @icon="cross"
+                 @title="Oeps! Dit is genant ..."
+                 @skin={{"error"}}
+                 @closable={{true}}
                  class="au-o-grid__item au-u-1-1 au-u-1-2@medium">
           <p>Er is iets onverwacht misgelopen tijdens het verwerken van uw zoekopdracht.</p>
           <p>Als dit probleem zich blijft voortdoen, twijfel er dan niet aan ondersteuning te contacteren.</p>

--- a/app/components/search-queries/filter-form.hbs
+++ b/app/components/search-queries/filter-form.hbs
@@ -16,8 +16,8 @@
     </div>
   </div>
   <div class="au-c-sidebar__footer au-c-sidebar__footer--border-top au-u-padding-none">
-    <AuToolbar @size="normal" style={{html-safe "min-height: 45px;"}}>
-      <AuToolbarGroup>
+    <AuToolbar @size="normal" style={{html-safe "min-height: 45px;"}} as |Group|>
+      <Group>
         <AuButton @skin="tertiary" {{ on "click" this.loadFilters }}>
           <AuIcon @icon="export" @alignment="left"/>
           Laad&nbsp;filters
@@ -30,7 +30,7 @@
           <AuIcon @icon="redo" @alignment="left"/>
           Reset
         </AuButton>
-      </AuToolbarGroup>
+      </Group>
     </AuToolbar>
   </div>
 </div>

--- a/app/components/submissions/regular-table.hbs
+++ b/app/components/submissions/regular-table.hbs
@@ -1,10 +1,10 @@
 <div class="au-c-body-container">
   <div class="au-o-box au-o-box--small au-u-hide-on-print">
-    <AuToolbar class="au-u-margin-bottom-small">
-      <AuToolbarGroup>
+    <AuToolbar class="au-u-margin-bottom-small" as |Group|>
+      <Group>
         <AuHeading @level="1" @skin="2">Toezicht ABB - Locatiesecretariaat</AuHeading>
-      </AuToolbarGroup>
-      <AuToolbarGroup>
+      </Group>
+      <Group>
         <AuButtonGroup>
           <span>
             <div class="checkbox--switch__wrapper">
@@ -16,7 +16,7 @@
             <AuIcon @icon="cross" @alignment="left" /> Herstel alle filters
           </AuButton>
         </AuButtonGroup>
-      </AuToolbarGroup>
+      </Group>
     </AuToolbar>
     {{!-- FILTERS --}}
     <div class="au-o-grid au-o-grid--tiny">

--- a/app/components/submissions/review.hbs
+++ b/app/components/submissions/review.hbs
@@ -1,6 +1,6 @@
 {{#if this.initStatuses.lastSuccessful}}
   <div>
-    <AuAlert @alertTitle="Medewerkers locatiesecretariaat" @alertsize={{"tiny"}} @alertskin={{"success"}}>
+    <AuAlert @title="Medewerkers locatiesecretariaat" @size="tiny" @skin="success">
       <label class="au-c-control au-c-control--checkbox">
         <Input @type="checkbox"
                class="au-c-control__input"

--- a/app/components/submissions/review.hbs
+++ b/app/components/submissions/review.hbs
@@ -1,5 +1,4 @@
 {{#if this.initStatuses.lastSuccessful}}
-<AuToolbarGroup>
   <div>
     <AuAlert @alertTitle="Medewerkers locatiesecretariaat" @alertsize={{"tiny"}} @alertskin={{"success"}}>
       <label class="au-c-control au-c-control--checkbox">
@@ -17,5 +16,4 @@
       <AuButton @skin="secondary" {{ on "click" this.cancel }}>Sluit venster</AuButton>
     </AuButtonGroup>
   </div>
-</AuToolbarGroup>
 {{/if}}

--- a/app/components/submissions/search-table.hbs
+++ b/app/components/submissions/search-table.hbs
@@ -67,14 +67,14 @@
             </c.body>
             <tr>
             <td colspan="8">
-              <AuAlert @alertIcon="alert-triangle" @alertTitle="PDF’s die ingescand zijn als afbeelding verschijnen niet in de zoekopdracht. Deze zijn niet leesbaar."  @alertskin={{"warning"}} @alertsize={{"small"}}>
+              <AuAlert @icon="alert-triangle" @title="PDF’s die ingescand zijn als afbeelding verschijnen niet in de zoekopdracht. Deze zijn niet leesbaar."  @skin="warning" @size="small">
                 <p>Verder zoeken we momenteel niet op op synoniemen of lokale varianten. Bepaalde documenten zullen we niet vinden.</p>
                 <br>
                 <p><strong>Oplossing</strong></p>
                 <p>Gebruik niet enkel de zoekfunctie om dossiers te doorzoeken &mdash; deze resultaten zijn beperkt. Maak gebruik van filters, zonder een zoekopdracht, om het volledige plaatje te zien. <a href="/help#help-zoekresultaten" target="_blank" rel="noopener noreferrer">Lees meer informatie over zoekresultaten</a>.</p>
               </AuAlert>
 
-              <AuAlert @alertIcon="info-circle" @alertTitle="De dossiers in deze tabel lopen maximaal één dag achter op de huidige stand van zaken."  @alertskin={{"info"}} @alertsize={{"small"}} class="au-u-margin-none" />
+              <AuAlert @icon="info-circle" @title="De dossiers in deze tabel lopen maximaal één dag achter op de huidige stand van zaken." @skin="info" @size="small" class="au-u-margin-none" />
             </td>
           </tr>
           </t.content>

--- a/app/components/submissions/vlabel-table.hbs
+++ b/app/components/submissions/vlabel-table.hbs
@@ -1,16 +1,16 @@
 <div class="au-c-body-container">
   <div class="au-o-box au-o-box--small au-u-hide-on-print">
-    <AuToolbar class="au-u-margin-bottom-small">
-      <AuToolbarGroup>
+    <AuToolbar class="au-u-margin-bottom-small" as |Group|>
+      <Group>
         <AuHeading @level="1" @skin="2">Toezicht ABB - Vlaamse Belastingsdienst</AuHeading>
-      </AuToolbarGroup>
-      <AuToolbarGroup>
+      </Group>
+      <Group>
         <AuButtonGroup>
           <AuButton {{on "click" this.resetFilters}} @skin="tertiary">
             <AuIcon @icon="cross" @alignment="left" /> Herstel alle filters
           </AuButton>
         </AuButtonGroup>
-      </AuToolbarGroup>
+      </Group>
     </AuToolbar>
 
     {{!-- FILTERS --}}

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -3,4 +3,8 @@ import { inject as service } from '@ember/service';
 
 export default class ApplicationController extends Controller {
   @service session;
+
+  logout = () => {
+    this.session.invalidate();
+  };
 }

--- a/app/controllers/mock-login.js
+++ b/app/controllers/mock-login.js
@@ -1,10 +1,9 @@
 import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
 import { task, timeout, restartableTask } from 'ember-concurrency';
 
 export default class MockLoginController extends Controller {
-  constructor() {
-    super(...arguments);
-  }
+  @service store;
 
   queryParams = ['gemeente', 'page'];
   gemeente = '';

--- a/app/controllers/search/submissions/show.js
+++ b/app/controllers/search/submissions/show.js
@@ -4,9 +4,10 @@ import { action } from '@ember/object';
 
 export default class SearchSubmissionsShowController extends Controller {
   @service currentSession;
+  @service router;
 
   @action
   onCloseComponent() {
-    this.transitionToRoute('search.submissions.index');
+    this.router.transitionTo('search.submissions.index');
   }
 }

--- a/app/controllers/supervision/submissions/show.js
+++ b/app/controllers/supervision/submissions/show.js
@@ -4,9 +4,10 @@ import { action } from '@ember/object';
 
 export default class SupervisionSubmissionsShowController extends Controller {
   @service currentSession;
+  @service router;
 
   @action
   onCloseComponent() {
-    this.transitionToRoute('supervision.submissions.index');
+    this.router.transitionTo('supervision.submissions.index');
   }
 }

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -4,15 +4,15 @@ import { inject as service } from '@ember/service';
 export default class IndexRoute extends Route {
   @service currentSession;
   @service session;
+  @service router;
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
 
     if (this.currentSession.canWrite || this.currentSession.canReadVlabel) {
-      this.transitionTo('supervision.submissions');
+      this.router.transitionTo('supervision.submissions');
     } else {
-      this.transitionTo('search.submissions');
+      this.router.transitionTo('search.submissions');
     }
-    super.beforeModel(...arguments);
   }
 }

--- a/app/routes/search/index.js
+++ b/app/routes/search/index.js
@@ -1,7 +1,10 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class SearchIndexRoute extends Route {
+  @service router;
+
   beforeModel(/* transition */) {
-    this.transitionTo('search.submissions');
+    this.router.transitionTo('search.submissions');
   }
 }

--- a/app/routes/search/submissions/search-queries/select.js
+++ b/app/routes/search/submissions/search-queries/select.js
@@ -1,4 +1,5 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 import { ForkingStore } from '@lblod/ember-submission-form-fields';
 import {
   formStoreToQueryParams,
@@ -8,6 +9,8 @@ import {
 import { FILTER_FORM_UUID } from '../../../../components/search-queries/filter-form';
 
 export default class SearchSubmissionSearchQueriesSelectRoute extends Route {
+  @service store;
+
   async model(params) {
     const store = new ForkingStore();
     const query = await this.store.findRecord('search-query', params.id);

--- a/app/routes/search/submissions/search-queries/select.js
+++ b/app/routes/search/submissions/search-queries/select.js
@@ -10,6 +10,7 @@ import { FILTER_FORM_UUID } from '../../../../components/search-queries/filter-f
 
 export default class SearchSubmissionSearchQueriesSelectRoute extends Route {
   @service store;
+  @service router;
 
   async model(params) {
     const store = new ForkingStore();
@@ -28,7 +29,7 @@ export default class SearchSubmissionSearchQueriesSelectRoute extends Route {
 
   afterModel(model) {
     const { store, node } = model;
-    this.transitionTo(
+    this.router.transitionTo(
       'search.submissions',
       formStoreToQueryParams(store, node)
     );

--- a/app/routes/search/submissions/show.js
+++ b/app/routes/search/submissions/show.js
@@ -1,6 +1,9 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class SearchSubmissionsShowRoute extends Route {
+  @service store;
+
   model(params) {
     return this.store.findRecord('submission', params.id, {
       include: [

--- a/app/routes/supervision.js
+++ b/app/routes/supervision.js
@@ -5,6 +5,7 @@ import { getOwner } from '@ember/application';
 export default class SupervisionRoute extends Route {
   @service currentSession;
   @service session;
+  @service router;
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
@@ -17,9 +18,9 @@ export default class SupervisionRoute extends Route {
         target == 'supervision.submissions.show' &&
         getOwner(this).lookup(`route:${showSearchRoute}`)
       ) {
-        this.transitionTo(showSearchRoute, transition.to.params.id);
+        this.router.transitionTo(showSearchRoute, transition.to.params.id);
       } else {
-        this.transitionTo('search');
+        this.router.transitionTo('search');
       }
     }
   }

--- a/app/routes/supervision/index.js
+++ b/app/routes/supervision/index.js
@@ -1,7 +1,10 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class SupervisionIndexRoute extends Route {
+  @service router;
+
   beforeModel(/* transition */) {
-    this.transitionTo('supervision.submissions');
+    this.router.transitionTo('supervision.submissions');
   }
 }

--- a/app/routes/supervision/submissions.js
+++ b/app/routes/supervision/submissions.js
@@ -12,6 +12,7 @@ export default class SupervisionSubmissionsRoute extends Route.extend(
   DataTableRouteMixin
 ) {
   @service currentSession;
+  @service store;
 
   modelName = 'submission';
 

--- a/app/routes/supervision/submissions/show.js
+++ b/app/routes/supervision/submissions/show.js
@@ -1,6 +1,9 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class SupervisionSubmissionsShowRoute extends Route {
+  @service store;
+
   model(params) {
     return this.store.findRecord('submission', params.id, {
       include: [

--- a/app/routes/toezicht/inzendingen/show.js
+++ b/app/routes/toezicht/inzendingen/show.js
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 
 export default class ToezichtInzendingenShowRoute extends Route {
   @service store;
+  @service router;
 
   async model(params) {
     const submissions = await this.store.query('submission', {
@@ -20,9 +21,15 @@ export default class ToezichtInzendingenShowRoute extends Route {
 
   afterModel(model) {
     if (model.submission) {
-      this.transitionTo('supervision.submissions.show', model.submission);
+      this.router.transitionTo(
+        'supervision.submissions.show',
+        model.submission
+      );
     } else {
-      this.transitionTo('route-not-found', `toezicht/inzendingen/${model.id}`);
+      this.router.transitionTo(
+        'route-not-found',
+        `toezicht/inzendingen/${model.id}`
+      );
     }
   }
 }

--- a/app/routes/toezicht/inzendingen/show.js
+++ b/app/routes/toezicht/inzendingen/show.js
@@ -1,6 +1,9 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class ToezichtInzendingenShowRoute extends Route {
+  @service store;
+
   async model(params) {
     const submissions = await this.store.query('submission', {
       filter: {

--- a/app/routes/user/search-queries/edit.js
+++ b/app/routes/user/search-queries/edit.js
@@ -1,6 +1,9 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class UserSearchQueriesEditRoute extends Route {
+  @service store;
+
   async model(params) {
     return await this.store.findRecord('search-query', params.id);
   }

--- a/app/routes/user/search-queries/index.js
+++ b/app/routes/user/search-queries/index.js
@@ -7,6 +7,7 @@ export default class UserSearchQueriesIndexRoute extends Route.extend(
   DataTableRouteMixin
 ) {
   @service currentSession;
+  @service store;
 
   queryParams = {
     page: { refreshModel: true },

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -7,9 +7,9 @@
   </li>
   <li class="au-c-list-horizontal__item">
     {{#if this.session.isAuthenticated}}
-      <AcmidmLogout @tagName="button" class="au-c-button au-c-button--tertiary" role="menuitem">
-        <AuIcon @icon="logout" @alignment="left" /> Afmelden
-      </AcmidmLogout>
+      <AuButton @skin="link" @icon="logout" {{on "click" this.logout}}>
+        Afmelden
+      </AuButton>
     {{else}}
       <LoginButton @isCompact={{true}} />
     {{/if}}

--- a/app/templates/login.hbs
+++ b/app/templates/login.hbs
@@ -6,13 +6,13 @@
   <section class="au-o-region-large">
     <div class="au-o-layout au-o-layout--small">
       <AuContent @skin="large">
-        <AuToolbar>
-          <AuToolbarGroup>
+        <AuToolbar as |Group|>
+          <Group>
             <AuHeading @level="1" @skin="1">Toezicht ABB</AuHeading>
-          </AuToolbarGroup>
-          <AuToolbarGroup>
+          </Group>
+          <Group>
             <LoginButton />
-          </AuToolbarGroup>
+          </Group>
         </AuToolbar>
         <p>Dit is de interne besluitendatabank voor medewerkers van het Agentschap Binnenlands Bestuur. Via deze databank zijn alle besluiten terug te vinden die door de lokale besturen gemeld of ingezonden werden via het Loket voor Lokale Besturen. Meer info over dit loket vind je op volgende pagina: <a href="https://mijnabb.be/ondersteuning/module-toezicht" rel="noopener noreferrer" target="_blank">https://mijnabb.be/ondersteuning/module-toezicht</a></p>
         <p>Lukt het aanmelden niet? Neem contact op met uw interne beheerder. Indien er zich een probleem voordoet, contacteer <a href="https://overheid.vlaanderen.be/ict/ict-diensten/gebruikersbeheer">gebruikersbeheer Vlaanderen</a>.</p>

--- a/app/templates/mock-login.hbs
+++ b/app/templates/mock-login.hbs
@@ -15,7 +15,7 @@
             <span class="au-u-hidden-visually">Aan het laden</span>
           {{else}}
             {{#if login.errorMessage}}
-              <AuAlert @alertIcon="info-circle" @alertTitle={{login.errorMessage}}  @alertskin={{"error"}}>{{login.errorMessage}}</AuAlert>
+              <AuAlert @icon="info-circle" @title={{login.errorMessage}} @skin="error">{{login.errorMessage}}</AuAlert>
             {{/if}}
             {{#each this.model as |account|}}
               <AuButton

--- a/app/templates/search/submissions.hbs
+++ b/app/templates/search/submissions.hbs
@@ -4,10 +4,10 @@
       <div class="au-o-grid au-o-grid--flush au-o-grid--fixed">
         <div class="au-o-grid__item {{if this.hasActiveChildRoute "au-u-4-6 au-u-visible-from@medium" "au-u-6-6"}}">
           <div class="au-c-body-container">
-            <AuToolbar @size="small" @border="bottom">
-              <AuToolbarGroup>
+            <AuToolbar @size="small" @border="bottom" as |Group|>
+              <Group>
                 <AuHeading @level="1" @skin="2" class="au-u-margin-top-tiny au-u-margin-bottom-tiny">Toezicht ABB</AuHeading>
-              </AuToolbarGroup>
+              </Group>
             </AuToolbar>
             <Submissions::SearchTable @model={{this.model}}
                                       @isLoading={{this.isLoadingModel}}

--- a/app/templates/search/submissions/show.hbs
+++ b/app/templates/search/submissions/show.hbs
@@ -1,21 +1,21 @@
 <div class="au-o-grid__item au-u-1-1 au-u-2-6@medium">
   <div class="au-c-body-container au-c-action-sidebar">
-    <AuToolbar @border="bottom" @size="large" @nowrap="true" tabindex="0">
-      <AuToolbarGroup>
+    <AuToolbar @border="bottom" @size="large" @nowrap="true" tabindex="0" as |Group|>
+      <Group>
         <div>
           <p class="au-u-margin-bottom-xsmall">
             <Submissions::StatusPill @status={{this.model.review.status}}/>
           </p>
           <AuHeading @level="2" @skin="3">Melding {{this.model.organization.fullName}}</AuHeading>
         </div>
-      </AuToolbarGroup>
-      <AuToolbarGroup>
+      </Group>
+      <Group>
         <div class="au-o-box">
           <LinkTo @route='search.submissions.index' class="link--icon--close">
             <span class="au-u-hidden-visually">Venster sluiten</span>
           </LinkTo>
         </div>
-      </AuToolbarGroup>
+      </Group>
     </AuToolbar>
     <div class="au-o-box au-c-body-container au-c-body-container--scroll">
       <div class="au-u-margin-bottom">
@@ -32,8 +32,8 @@
         <Submissions::Form @submission={{this.model}}/>
       </div>
     </div>
-    <AuToolbar @border="top" @size="large" class="au-u-hide-on-print">
-      <AuToolbarGroup>
+    <AuToolbar @border="top" @size="large" class="au-u-hide-on-print" as |Group|>
+      <Group>
         {{#if this.currentSession.canWrite}}
           <Submissions::Review
                   @model={{await this.model.review}}
@@ -45,7 +45,7 @@
             <LinkTo @route="search.submissions.index" class="au-c-button au-c-button--secondary">Sluit venster</LinkTo>
           </AuButtonGroup>
         {{/if}}
-      </AuToolbarGroup>
+      </Group>
     </AuToolbar>
   </div>
 </div>

--- a/app/templates/supervision/submissions/show.hbs
+++ b/app/templates/supervision/submissions/show.hbs
@@ -1,21 +1,21 @@
 <div class="au-o-grid__item au-u-1-1 au-u-2-5@medium">
   <div class="au-c-body-container au-c-action-sidebar">
-    <AuToolbar @border="bottom" @size="large" @nowrap="true" tabindex="0">
-      <AuToolbarGroup>
+    <AuToolbar @border="bottom" @size="large" @nowrap="true" tabindex="0" as |Group|>
+      <Group>
         <div>
           <p class="au-u-margin-bottom-xsmall">
             <Submissions::StatusPill @status={{this.model.review.status}}/>
           </p>
           <AuHeading @level="2" @skin="3">Melding {{this.model.organization.fullName}}</AuHeading>
         </div>
-      </AuToolbarGroup>
-      <AuToolbarGroup>
+      </Group>
+      <Group>
         <div class="au-o-box">
           <LinkTo @route='supervision.submissions.index' class="link--icon--close">
             <span class="au-u-hidden-visually">Venster sluiten</span>
           </LinkTo>
         </div>
-      </AuToolbarGroup>
+      </Group>
     </AuToolbar>
     <div class="au-o-box au-c-body-container au-c-body-container--scroll">
       <div class="au-u-margin-bottom">
@@ -38,7 +38,8 @@
       </div>
       <Submissions::Form @submission={{this.model}}/>
     </div>
-    <AuToolbar @border="top" @size="large" class="au-u-hide-on-print">
+    <AuToolbar @border="top" @size="large" class="au-u-hide-on-print" as |Group|>
+      <Group>
         {{#if this.currentSession.canWrite}}
           <Submissions::Review
                   @model={{await this.model.review}}
@@ -49,6 +50,7 @@
             <LinkTo @route="supervision.submissions.index" class="au-c-button au-c-button--secondary">Sluit venster</LinkTo>
           </div>
         {{/if}}
+      </Group>
     </AuToolbar>
   </div>
 </div>

--- a/app/templates/user/search-queries/index.hbs
+++ b/app/templates/user/search-queries/index.hbs
@@ -1,7 +1,7 @@
 {{!-- TODO: Turn this into a modal when the button is seperated from the modal --}}
 <div class="au-c-body-container">
-  <AuToolbar @size="medium" @skin="tint" @border="bottom">
-    <AuToolbarGroup>
+  <AuToolbar @size="medium" @skin="tint" @border="bottom" as |Group|>
+    <Group>
       <ul class="au-c-list-horizontal">
         <li class="au-c-list-horizontal__item">
           <AuLink @route="search.submissions">
@@ -13,16 +13,16 @@
           <strong>Bewaarde zoekopdrachten</strong>
         </li>
       </ul>
-    </AuToolbarGroup>
+    </Group>
   </AuToolbar>
 
-  <AuToolbar @size="large">
-    <AuToolbarGroup>
+  <AuToolbar @size="large" as |Group|>
+    <Group>
       <AuHeading @level="1" @skin="2" class="au-u-margin-top-tiny au-u-margin-bottom-tiny">
         Bewaarde zoekopdrachten
       </AuHeading>
-    </AuToolbarGroup>
-    <AuToolbarGroup>
+    </Group>
+    <Group>
       <AuButtonGroup>
         <LinkTo @route="user.search-queries.new" class="au-c-button" type="button">
           Maak nieuwe zoekopdracht
@@ -31,7 +31,7 @@
           Terug naar toezicht
         </AuLink>
       </AuButtonGroup>
-    </AuToolbarGroup>
+    </Group>
   </AuToolbar>
 
   <AuDataTable

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -5,6 +5,9 @@ const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 module.exports = function (defaults) {
   let app = new EmberApp(defaults, {
     // Add options here
+    '@appuniversum/ember-appuniversum': {
+      dutchDatePickerLocalization: true,
+    },
     'ember-cli-babel': {
       includePolyfill: true,
     },


### PR DESCRIPTION
This fixes all deprecations (in our own code) that are blocking the Ember v4 and Appuniversum v2 update. There are a couple of ember-modifier related deprecations but those will be resolved when updating to Appuniversum v2 and ember-power-select v6.