### PR TITLE
Update to rdflib v2

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -10,4 +10,12 @@ export default class App extends Application {
   Resolver = Resolver;
 }
 
+// By default `Array.prototype._super` is enumerable which causes conflicts with rdflib.
+// We can force it to be non-enumerable so everything works as expected.
+// This code can be removed once the bug is fixed and released, or if we disable the prototype extensions in the app.
+// More information: https://github.com/emberjs/ember.js/issues/19289
+Object.defineProperty(Array.prototype, '_super', {
+  enumerable: false,
+});
+
 loadInitializers(App, config.modulePrefix);

--- a/app/components/submissions/form.js
+++ b/app/components/submissions/form.js
@@ -3,13 +3,13 @@ import { inject as service } from '@ember/service';
 import { warn } from '@ember/debug';
 import { tracked } from '@glimmer/tracking';
 
-import rdflib from 'browser-rdflib';
+import { NamedNode, Namespace } from 'rdflib';
 import fetch from 'fetch';
 import { ForkingStore } from '@lblod/ember-submission-form-fields';
 import { task } from 'ember-concurrency';
 
-const RDF = new rdflib.Namespace('http://www.w3.org/1999/02/22-rdf-syntax-ns#');
-const FORM = new rdflib.Namespace('http://lblod.data.gift/vocabularies/forms/');
+const RDF = new Namespace('http://www.w3.org/1999/02/22-rdf-syntax-ns#');
+const FORM = new Namespace('http://lblod.data.gift/vocabularies/forms/');
 
 export default class SubmissionsFormComponent extends Component {
   @service store;
@@ -43,12 +43,12 @@ export default class SubmissionsFormComponent extends Component {
 
     const formStore = new ForkingStore();
 
-    const metaGraph = new rdflib.NamedNode('http://data.lblod.info/metagraph');
+    const metaGraph = new NamedNode('http://data.lblod.info/metagraph');
     formStore.parse(meta, metaGraph, 'text/turtle');
-    const formGraph = new rdflib.NamedNode('http://data.lblod.info/form');
+    const formGraph = new NamedNode('http://data.lblod.info/form');
     formStore.parse(form, formGraph, 'text/turtle');
 
-    const sourceGraph = new rdflib.NamedNode(
+    const sourceGraph = new NamedNode(
       `http://data.lblod.info/submission-document/data/${submissionDocument.id}`
     );
     if (removals || additions) {
@@ -66,6 +66,6 @@ export default class SubmissionsFormComponent extends Component {
     this.formStore = formStore;
     this.graphs = { formGraph, sourceGraph, metaGraph };
     this.form = formStore.any(undefined, RDF('type'), FORM('Form'), formGraph);
-    this.sourceNode = new rdflib.NamedNode(submissionDocument.uri);
+    this.sourceNode = new NamedNode(submissionDocument.uri);
   }
 }

--- a/app/utils/filter-form-helpers.js
+++ b/app/utils/filter-form-helpers.js
@@ -1,25 +1,21 @@
-import rdflib from 'browser-rdflib';
+import { NamedNode, Namespace, serialize } from 'rdflib';
 import fetch from 'fetch';
 
-export const RDF = new rdflib.Namespace(
-  'http://www.w3.org/1999/02/22-rdf-syntax-ns#'
-);
-export const FORM = new rdflib.Namespace(
-  'http://lblod.data.gift/vocabularies/forms/'
-);
-export const SH = new rdflib.Namespace('http://www.w3.org/ns/shacl#');
-export const SEARCH = new rdflib.Namespace(
+export const RDF = new Namespace('http://www.w3.org/1999/02/22-rdf-syntax-ns#');
+export const FORM = new Namespace('http://lblod.data.gift/vocabularies/forms/');
+export const SH = new Namespace('http://www.w3.org/ns/shacl#');
+export const SEARCH = new Namespace(
   'http://redpencil.data.gift/vocabularies/search-queries/'
 );
 
-export const TEMP_SOURCE_NODE = new rdflib.NamedNode(
+export const TEMP_SOURCE_NODE = new NamedNode(
   'http://frontend-toezicht-abb/temp-source-node'
 );
 
 export const FORM_GRAPHS = {
-  formGraph: new rdflib.NamedNode('http://data.lblod.info/form'),
-  metaGraph: new rdflib.NamedNode('http://data.lblod.info/metagraph'),
-  sourceGraph: new rdflib.NamedNode(`http://data.lblod.info/sourcegraph`),
+  formGraph: new NamedNode('http://data.lblod.info/form'),
+  metaGraph: new NamedNode('http://data.lblod.info/metagraph'),
+  sourceGraph: new NamedNode(`http://data.lblod.info/sourcegraph`),
 };
 
 // API CALLS
@@ -43,7 +39,7 @@ export async function retrieveMetaData(url, store) {
 }
 
 export async function retrieveSourceData(uri, url, store) {
-  const sourceNode = new rdflib.NamedNode(uri);
+  const sourceNode = new NamedNode(uri);
 
   // NOTE: update everything that exists in the source-graph to the given URI
   const existing = store.match(
@@ -70,7 +66,7 @@ export async function retrieveSourceData(uri, url, store) {
 export async function saveSourceData(url, store) {
   // NOTE: store.serializeDataMergedGraph() will always use format 'text/turtle', regardless of attempts to override this
   // there for the function has been "copied" from the forking-store to add 'application/n-triples' as serialization format.
-  const body = rdflib.serialize(
+  const body = serialize(
     store.mergedGraph(FORM_GRAPHS.sourceGraph),
     store.graph,
     undefined,
@@ -177,7 +173,7 @@ export function queryParamsToFormStore(query, store, node) {
       const values = query[key] && query[key].split(',');
       if (values && values.length) {
         for (let value of values) {
-          const rdfv = validURI(value) ? new rdflib.NamedNode(value) : value;
+          const rdfv = validURI(value) ? new NamedNode(value) : value;
           store.graph.add(node, path, rdfv, FORM_GRAPHS.sourceGraph);
         }
       }

--- a/package.json
+++ b/package.json
@@ -27,11 +27,9 @@
     "test:ember": "ember test"
   },
   "overrides": {
-    "@appuniversum/ember-appuniversum": "$@appuniversum/ember-appuniversum",
     "ember-cli-babel": "$ember-cli-babel"
   },
   "overridesNotes": {
-    "@appuniversum/ember-appuniversum": "ember-submission-form-fields v1 doesn't support v2 yet, so we override it until we update to v2 of that addon",
     "ember-cli-babel": "torii and ember-cli-deploy-ssh-index bring in ember-cli-babel v6 which triggers the build warning"
   },
   "devDependencies": {
@@ -43,10 +41,9 @@
     "@glimmer/tracking": "^1.0.4",
     "@lblod/ember-acmidm-login": "^1.0.0",
     "@lblod/ember-mock-login": "^0.7.0",
-    "@lblod/ember-submission-form-fields": "^1.9.2",
+    "@lblod/ember-submission-form-fields": "^2.6.1",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
-    "browser-rdflib": "^1.1.0",
     "ember-auto-import": "^2.6.0",
     "ember-cli": "~3.28.6",
     "ember-cli-app-version": "^6.0.0",
@@ -72,7 +69,7 @@
     "ember-moment": "^10.0.0",
     "ember-mu-transform-helpers": "^2.0.0",
     "ember-page-title": "^7.0.0",
-    "ember-power-select": "^5.0.1",
+    "ember-power-select": "^6.0.1",
     "ember-promise-helpers": "^2.0.0",
     "ember-qunit": "^5.1.5",
     "ember-resolver": "^8.0.3",
@@ -93,6 +90,7 @@
     "prettier": "^2.5.1",
     "qunit": "^2.17.2",
     "qunit-dom": "^2.0.0",
+    "rdflib": "^2.2.26",
     "release-it": "^15.5.0",
     "sass": "^1.23.7",
     "webpack": "^5.75.0"


### PR DESCRIPTION
`browser-rdflib` is no longer needed in modern apps. This also allows us to update to ember-submission-formfields v2 since it uses rdflib v2 as well.