### PR TITLE
Fix the reset filters functionality

### DIFF
--- a/app/components/search-queries/filter-form.hbs
+++ b/app/components/search-queries/filter-form.hbs
@@ -1,17 +1,17 @@
 <div class="au-c-sidebar">
   <div class="au-c-sidebar__content">
     <div class="au-c-sidebar__header">
-      {{#if this.init.isRunning}}
-        <span>Aan het laden...</span>
+      {{#if (or this.init.isRunning this.resetFilters.isRunning)}}
+        <AuLoader @size="small" />
       {{else}}
         <RdfForm
-                @groupClass="au-o-grid__item au-u-1-2 au-u-1-1@small"
-                @form={{this.form}}
-                @graphs={{this.graphs}}
-                @sourceNode={{this.sourceNode}}
-                @formStore={{this.formStore}}
-                @show={{if this.resetFilters.isRunning true false}}
-                @forceShowErrors={{false}} />
+          @groupClass="au-o-grid__item au-u-1-2 au-u-1-1@small"
+          @form={{this.form}}
+          @graphs={{this.graphs}}
+          @sourceNode={{this.sourceNode}}
+          @formStore={{this.formStore}}
+          @forceShowErrors={{false}}
+        />
       {{/if}}
     </div>
   </div>

--- a/app/components/search-queries/filter-form.js
+++ b/app/components/search-queries/filter-form.js
@@ -40,7 +40,7 @@ export default class SearchQueriesFilterFormComponent extends SearchQueriesFormC
 
   // NOTE: the problem here lies in that if an outsider makes changes in the store,
   // the field components are not aware of this. There for, for now, we force the form to rerender by temporarily
-  // changing the "show" argument.
+  // not rendering the form and showing a loader instead.
   @task
   *resetFilters() {
     yield super.setupForm(FILTER_FORM_UUID);


### PR DESCRIPTION
Due to internal changes using the `@show` argument to reset the state no longer works. We now temporarily stop rendering the `<RdfForm>` component so that all the state is reset.