### PR TITLE
Remove ember-cli-string-helpers

### DIFF
--- a/app/components/search-queries/filter-form.hbs
+++ b/app/components/search-queries/filter-form.hbs
@@ -16,7 +16,8 @@
     </div>
   </div>
   <div class="au-c-sidebar__footer au-c-sidebar__footer--border-top au-u-padding-none">
-    <AuToolbar @size="normal" style={{html-safe "min-height: 45px;"}} as |Group|>
+    {{! template-lint-disable no-inline-styles}}
+    <AuToolbar @size="normal" style="min-height: 45px;" as |Group|>
       <Group>
         <AuButton @skin="tertiary" {{ on "click" this.loadFilters }}>
           <AuIcon @icon="export" @alignment="left"/>

--- a/app/components/submissions/regular-table.hbs
+++ b/app/components/submissions/regular-table.hbs
@@ -104,13 +104,13 @@
           {{#unless @displaySubset}}
             <td class="au-u-visible-from@medium">{{row.organization.provincie.naam}}</td>
           {{/unless}}
-          <td class="au-u-visible-until@small" style={{html-safe "max-width: 250px;"}}>
+          <td class="au-u-visible-until@small" style="max-width: 250px;" {{! template-lint-disable no-inline-styles}}>
             {{row.organization.naam}}
             <br>
             <AuHelpText class="au-u-hidden-from@medium text-fade">{{row.organization.classificatie.label}}</AuHelpText>
           </td>
           <td class="au-u-visible-from@medium">{{row.organization.classificatie.label}}</td>
-          <td style={{html-safe "max-width: 250px;"}}>
+          <td style="max-width: 250px;" {{! template-lint-disable no-inline-styles}}>
             {{#if row.formData.decisionType}}
               <p>{{row.formData.decisionType.label}}</p>
             {{else}}
@@ -122,7 +122,7 @@
             <td class="au-u-visible-from@medium">{{moment-format row.formData.sessionStartedAtTime 'DD-MM-YYYY'}}</td>
             <td class="au-u-visible-from@medium">{{moment-format row.sentDate 'DD-MM-YYYY'}}</td>
           {{/unless}}
-          <td style={{html-safe "max-width:120px;"}}>
+          <td style="max-width:120px;" {{! template-lint-disable no-inline-styles}}>
             <Submissions::StatusPill @status={{row.review.status}}/>{{!--  <AuPill resource="{{capitalize row.status}}">{{capitalize row.status}}</AuPill> --}}
           </td>
           <td class="au-u-hide-on-print">

--- a/app/components/submissions/regular-table.hbs
+++ b/app/components/submissions/regular-table.hbs
@@ -123,7 +123,7 @@
             <td class="au-u-visible-from@medium">{{moment-format row.sentDate 'DD-MM-YYYY'}}</td>
           {{/unless}}
           <td style="max-width:120px;" {{! template-lint-disable no-inline-styles}}>
-            <Submissions::StatusPill @status={{row.review.status}}/>{{!--  <AuPill resource="{{capitalize row.status}}">{{capitalize row.status}}</AuPill> --}}
+            <Submissions::StatusPill @status={{row.review.status}}/>
           </td>
           <td class="au-u-hide-on-print">
             <LinkTo @route="supervision.submissions.show" @model={{row.id}}>Bekijk</LinkTo>

--- a/app/components/submissions/search-table.hbs
+++ b/app/components/submissions/search-table.hbs
@@ -59,7 +59,7 @@
                 <td class="au-u-visible-from@medium">{{moment-format row.sentDate 'DD-MM-YYYY'}}</td>
               {{/unless}}
               <td style="max-width:120px;" {{! template-lint-disable no-inline-styles}}>
-                <AuPill resource="{{capitalize row.status}}">{{capitalize row.status}}</AuPill>
+                <AuPill resource={{row.status}}>{{row.status}}</AuPill>
               </td>
               <td class="au-u-hide-on-print" style="width:70px;" {{! template-lint-disable no-inline-styles}}>
                 <LinkTo @route="search.submissions.show" @model={{row.id}}>Bekijk</LinkTo>

--- a/app/components/submissions/search-table.hbs
+++ b/app/components/submissions/search-table.hbs
@@ -36,7 +36,7 @@
               {{#unless @displaySubset}}
                 <td class="au-u-visible-from@medium">{{row.province}}</td>
               {{/unless}}
-              <td style={{html-safe "max-width: 175px;"}}>{{row.administrativeUnit}}
+              <td style="max-width: 175px;" {{! template-lint-disable no-inline-styles}}>{{row.administrativeUnit}}
                 {{#if @displaySubset}}
                   <p class="text-fade">{{row.administrativeUnitClassification}}</p>
                 {{else}}
@@ -46,7 +46,7 @@
               {{#unless @displaySubset}}
                 <td class="au-u-visible-from@medium">{{row.administrativeUnitClassification}}</td>
               {{/unless}}
-              <td style={{html-safe "max-width: 200px;"}}>
+              <td style="max-width: 200px;" {{! template-lint-disable no-inline-styles}}>
                 {{#if row.decisionType}}
                   <p>{{row.decisionType}}</p>
                 {{else}}
@@ -58,10 +58,10 @@
                 <td class="au-u-visible-from@medium">{{moment-format row.sessionDatetime 'DD-MM-YYYY HH:mm'}}</td>
                 <td class="au-u-visible-from@medium">{{moment-format row.sentDate 'DD-MM-YYYY'}}</td>
               {{/unless}}
-              <td style={{html-safe "max-width:120px;"}}>
+              <td style="max-width:120px;" {{! template-lint-disable no-inline-styles}}>
                 <AuPill resource="{{capitalize row.status}}">{{capitalize row.status}}</AuPill>
               </td>
-              <td class="au-u-hide-on-print" style={{html-safe "width:70px;"}}>
+              <td class="au-u-hide-on-print" style="width:70px;" {{! template-lint-disable no-inline-styles}}>
                 <LinkTo @route="search.submissions.show" @model={{row.id}}>Bekijk</LinkTo>
               </td>
             </c.body>

--- a/app/components/submissions/status-pill.hbs
+++ b/app/components/submissions/status-pill.hbs
@@ -1,1 +1,1 @@
-<AuPill class="au-u-margin-bottom-tiny" resource={{@status.uri}}>{{capitalize @status.label}}</AuPill>
+<AuPill class="au-u-margin-bottom-tiny" resource={{@status.uri}}>{{@status.label}}</AuPill>

--- a/app/components/submissions/vlabel-table.hbs
+++ b/app/components/submissions/vlabel-table.hbs
@@ -82,14 +82,12 @@
           <th class="au-u-hide-on-print"></th>
         </c.header>
         <c.body as |row|>
-
-          <td style={{html-safe "max-width: 100px;"}}>
+          <td style="max-width: 100px;" {{! template-lint-disable no-inline-styles}}>
             {{row.organization.naam}}
             <br>
             <AuHelpText class="au-u-hidden-from@medium text-fade">{{row.organization.classificatie.label}}</AuHelpText>
           </td>
-
-          <td style={{html-safe "max-width: 150px;"}}>{{row.formData.chartOfAccount.notation}} - {{row.formData.chartOfAccount.label}}</td>
+          <td style="max-width: 150px;" {{! template-lint-disable no-inline-styles}}>{{row.formData.chartOfAccount.notation}} - {{row.formData.chartOfAccount.label}}</td>
           {{#unless @displaySubset}}
             <td class="au-u-visible-from@medium">{{moment-format row.formData.sessionStartedAtTime 'DD-MM-YYYY'}}</td>
             <td class="au-u-visible-from@medium">{{moment-format row.sentDate 'DD-MM-YYYY'}}</td>

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-sass": "^11.0.1",
     "ember-cli-sri": "^2.1.1",
-    "ember-cli-string-helpers": "^6.0.0",
     "ember-cli-terser": "^4.0.2",
     "ember-concurrency": "^2.3.7",
     "ember-data": "~3.28.6",
@@ -94,9 +93,6 @@
     "release-it": "^15.5.0",
     "sass": "^1.23.7",
     "webpack": "^5.75.0"
-  },
-  "dependencyRemovalNotes": {
-    "ember-cli-string-helpers": "capitalize and html-safe are still used."
   },
   "engines": {
     "node": "12.* || 14.* || >= 16"


### PR DESCRIPTION
This addon is not really needed anymore and it will trigger deprecations on later ember-cli versions.