### PR TITLE
Refresh the model when deleting search queries

### DIFF
--- a/app/controllers/user/search-queries/index.js
+++ b/app/controllers/user/search-queries/index.js
@@ -1,16 +1,20 @@
 import Controller from '@ember/controller';
+import { service } from '@ember/service';
 
 import { task } from 'ember-concurrency';
 import { removeSourceData } from '../../../utils/filter-form-helpers';
 
 export default class UserSearchQueriesIndexController extends Controller {
+  @service router;
+
   page = 0;
   size = 10;
   sort = '-created';
 
   @task
   *delete(id) {
+    // TODO: The backend needs to be updated so Ember Data's `record.destroyRecord()` method works and we don't need the route refreshing code anymore
     yield removeSourceData(`/search-queries/${id}`);
-    yield this.model.update();
+    this.router.refresh('user.search-queries.index');
   }
 }


### PR DESCRIPTION
`this.model.update` no longer works or doesn't trigger a rerender. We can work around this by simply reloading the model hook. Ideally we can use `record.destroyRecord()` but that requires backend changes.