### PR TITLE
Downgrade Ember Data to v4.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "ember-cli-sri": "^2.1.1",
         "ember-cli-terser": "^4.0.2",
         "ember-concurrency": "^2.3.7",
-        "ember-data": "~4.12.0",
+        "ember-data": "~4.11.0",
         "ember-fetch": "^8.1.2",
         "ember-load-initializers": "^2.1.2",
         "ember-modifier": "^3.2.0",
@@ -2260,143 +2260,89 @@
       }
     },
     "node_modules/@ember-data/adapter": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@ember-data/adapter/-/adapter-4.12.0.tgz",
-      "integrity": "sha512-sY7Zm73LSN1x1jO+lTV0+Vtdis6rBFAuRD3sln1BOW0y9che5WK+qyQs8FhjC6m9D/FFIKqUucWvaPO4/GazuQ==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@ember-data/adapter/-/adapter-4.11.3.tgz",
+      "integrity": "sha512-G7dbaPnYMW8VYxIT75KAkzax2mkWTs2TYxS7+qbphs6esXpO9Y/iNp5fTqLaACb9JqUypwEA/rlfC7/zkcGbBw==",
       "dev": true,
       "dependencies": {
-        "@ember-data/private-build-infra": "4.12.0",
+        "@ember-data/private-build-infra": "4.11.3",
+        "@ember/edition-utils": "^1.2.0",
         "@embroider/macros": "^1.10.0",
+        "ember-auto-import": "^2.4.3",
         "ember-cli-babel": "^7.26.11",
         "ember-cli-test-info": "^1.0.0"
       },
       "engines": {
-        "node": "16.* || >= 18.*"
+        "node": "^14.8.0 || 16.* || >= 18.*"
       },
       "peerDependencies": {
-        "@ember-data/store": "4.12.0",
+        "@ember-data/store": "4.11.3",
         "@ember/string": "^3.0.1",
         "ember-inflector": "^4.0.2"
       }
     },
-    "node_modules/@ember-data/debug": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@ember-data/debug/-/debug-4.12.0.tgz",
-      "integrity": "sha512-6SNJjoV3zKnjjZEu9/tOjeWdN70mxmkvHd+0Y7kjasmjLBgIkZk20+B/nFm25MpmmpfZEsvdUY3HIfu+iPy+5A==",
+    "node_modules/@ember-data/canary-features": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@ember-data/canary-features/-/canary-features-4.11.3.tgz",
+      "integrity": "sha512-RTLY2N9t1SXr4e90VBKi+3PIitwjTMBU8BcEhnKovT//sGlywohHq7T36H6nJuITRtki3On9PpbJOhhQZuyAlQ==",
       "dev": true,
       "dependencies": {
-        "@ember-data/private-build-infra": "4.12.0",
-        "@ember/edition-utils": "^1.2.0",
         "@embroider/macros": "^1.10.0",
-        "ember-auto-import": "^2.6.1",
         "ember-cli-babel": "^7.26.11"
       },
       "engines": {
-        "node": "16.* || >= 18.*"
+        "node": "^14.8.0 || 16.* || >= 18.*"
+      }
+    },
+    "node_modules/@ember-data/debug": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@ember-data/debug/-/debug-4.11.3.tgz",
+      "integrity": "sha512-3pA5u3qy+pjtwcoyMzs7WijRrSQz5z+Vgn9b5Y4cEOHn8loS9riLCMScnFaQT3HjxQgq+3NkNb52sJafHPzs4Q==",
+      "dev": true,
+      "dependencies": {
+        "@ember-data/private-build-infra": "4.11.3",
+        "@ember/edition-utils": "^1.2.0",
+        "@embroider/macros": "^1.10.0",
+        "ember-auto-import": "^2.4.3",
+        "ember-cli-babel": "^7.26.11"
+      },
+      "engines": {
+        "node": "^14.8.0 || 16.* || >= 18.*"
       },
       "peerDependencies": {
         "@ember/string": "^3.0.1"
       }
     },
-    "node_modules/@ember-data/graph": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@ember-data/graph/-/graph-4.12.0.tgz",
-      "integrity": "sha512-5crSekONC8cm/sPS4OnNNG1TrnCb4rqrM72Ux8i8xlomYpLq75R2gY4ibY1HRNstrEoAB09rzONTB0bRJHlTQw==",
-      "dev": true,
-      "dependencies": {
-        "@ember-data/private-build-infra": "4.12.0",
-        "@ember/edition-utils": "^1.2.0",
-        "@embroider/macros": "^1.10.0",
-        "ember-cli-babel": "^7.26.11"
-      },
-      "engines": {
-        "node": "16.* || >= 18.*"
-      },
-      "peerDependencies": {
-        "@ember-data/store": "4.12.0"
-      }
-    },
-    "node_modules/@ember-data/json-api": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@ember-data/json-api/-/json-api-4.12.0.tgz",
-      "integrity": "sha512-vtxuB7akuSfsEBvLX/8h4zGyIozynyq5Bf9I02ftIoIIwD21wN+g/ZG91KU6sNZzyeycTZEKpoYaITM84pLTTg==",
-      "dev": true,
-      "dependencies": {
-        "@ember-data/private-build-infra": "4.12.0",
-        "@ember/edition-utils": "^1.2.0",
-        "@embroider/macros": "^1.10.0",
-        "ember-cli-babel": "^7.26.11"
-      },
-      "engines": {
-        "node": "16.* || >= 18.*"
-      },
-      "peerDependencies": {
-        "@ember-data/graph": "4.12.0",
-        "@ember-data/store": "4.12.0"
-      }
-    },
-    "node_modules/@ember-data/legacy-compat": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@ember-data/legacy-compat/-/legacy-compat-4.12.0.tgz",
-      "integrity": "sha512-QVZczGMbTk8Ch+xiZt7KQk5UX2AdUsVdR3rSB/pJVZrWcUWo6ToAR2mPl97/cWd6VYFXBZgMamsxkeBO4q5HXA==",
-      "dev": true,
-      "dependencies": {
-        "@ember-data/private-build-infra": "4.12.0",
-        "@embroider/macros": "^1.10.0",
-        "ember-cli-babel": "^7.26.11"
-      },
-      "engines": {
-        "node": "16.* || >= 18"
-      },
-      "peerDependencies": {
-        "@ember-data/graph": "4.12.0",
-        "@ember-data/json-api": "4.12.0"
-      },
-      "peerDependenciesMeta": {
-        "@ember-data/graph": {
-          "optional": true
-        },
-        "@ember-data/json-api": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@ember-data/model": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@ember-data/model/-/model-4.12.0.tgz",
-      "integrity": "sha512-gE9LRmUkrJy9hJ+WeNns/GOMQC311R18SOvbsIVk5z/u2tgD5l0BjLSeqCaG/CjO+fCRsM8Ne/Ivm07c/CyezQ==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@ember-data/model/-/model-4.11.3.tgz",
+      "integrity": "sha512-nkDru5TZmOp4J1xp65D1bR3hBJ3u5KhKKfDpWeGnHW2YDCVUdLORRwW7vfrPnnXDIoJij42DwDVCiTY25Xhrqw==",
       "dev": true,
       "dependencies": {
-        "@ember-data/private-build-infra": "4.12.0",
+        "@ember-data/canary-features": "4.11.3",
+        "@ember-data/private-build-infra": "4.11.3",
         "@ember/edition-utils": "^1.2.0",
         "@embroider/macros": "^1.10.0",
+        "ember-auto-import": "^2.4.3",
         "ember-cached-decorator-polyfill": "^1.0.1",
         "ember-cli-babel": "^7.26.11",
         "ember-cli-string-utils": "^1.1.0",
         "ember-cli-test-info": "^1.0.0",
-        "inflection": "~2.0.1"
+        "ember-compatibility-helpers": "^1.2.6",
+        "inflection": "~2.0.0"
       },
       "engines": {
-        "node": "16.* || >= 18.*"
+        "node": "^14.8.0 || 16.* || >= 18.*"
       },
       "peerDependencies": {
-        "@ember-data/debug": "4.12.0",
-        "@ember-data/graph": "4.12.0",
-        "@ember-data/json-api": "4.12.0",
-        "@ember-data/legacy-compat": "4.12.0",
-        "@ember-data/store": "4.12.0",
-        "@ember-data/tracking": "4.12.0",
+        "@ember-data/record-data": "4.11.3",
+        "@ember-data/store": "4.11.3",
+        "@ember-data/tracking": "4.11.3",
         "@ember/string": "^3.0.1",
         "ember-inflector": "^4.0.2"
       },
       "peerDependenciesMeta": {
-        "@ember-data/debug": {
-          "optional": true
-        },
-        "@ember-data/graph": {
-          "optional": true
-        },
-        "@ember-data/json-api": {
+        "@ember-data/record-data": {
           "optional": true
         }
       }
@@ -2411,14 +2357,15 @@
       }
     },
     "node_modules/@ember-data/private-build-infra": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@ember-data/private-build-infra/-/private-build-infra-4.12.0.tgz",
-      "integrity": "sha512-cBuEZhxV8uyIRr+9oUZ4smQb+6p6ryH89+WdrGMTeKgKP3XkdlK9w+6veQAYOqgWAulTwmAxX+YU/zoPq2ne7w==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@ember-data/private-build-infra/-/private-build-infra-4.11.3.tgz",
+      "integrity": "sha512-bXFQMEegUc+vKn/vD7FmAkq7ECE0okZ2sbtv/0RXqYn7TLk44rvGzpqSUXUowpCaGI/87MmaW8JaZMMdqF9wuw==",
       "dev": true,
       "dependencies": {
-        "@babel/core": "^7.21.4",
-        "@babel/plugin-transform-block-scoping": "^7.21.0",
-        "@babel/runtime": "^7.21.0",
+        "@babel/core": "^7.20.2",
+        "@babel/plugin-transform-block-scoping": "^7.20.2",
+        "@babel/runtime": "^7.20.1",
+        "@ember-data/canary-features": "4.11.3",
         "@ember/edition-utils": "^1.2.0",
         "@embroider/macros": "^1.10.0",
         "babel-import-util": "^1.3.0",
@@ -2437,13 +2384,15 @@
         "ember-cli-string-utils": "^1.1.0",
         "ember-cli-version-checker": "^5.1.2",
         "git-repo-info": "^2.1.1",
-        "glob": "^9.3.4",
+        "glob": "^8.0.3",
         "npm-git-info": "^1.0.3",
+        "rimraf": "^3.0.2",
+        "rsvp": "^4.8.5",
         "semver": "^7.3.8",
         "silent-error": "^1.1.1"
       },
       "engines": {
-        "node": "16.* || >= 18.*"
+        "node": "^14.8.0 || 16.* || >= 18.*"
       }
     },
     "node_modules/@ember-data/private-build-infra/node_modules/brace-expansion": {
@@ -2487,45 +2436,34 @@
       }
     },
     "node_modules/@ember-data/private-build-infra/node_modules/glob": {
-      "version": "9.3.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
-      "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
       "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
-        "minimatch": "^8.0.2",
-        "minipass": "^4.2.4",
-        "path-scurry": "^1.6.1"
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@ember-data/private-build-infra/node_modules/minimatch": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
-      "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@ember-data/private-build-infra/node_modules/minipass": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
-      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
+        "node": ">=10"
       }
     },
     "node_modules/@ember-data/private-build-infra/node_modules/promise-map-series": {
@@ -2594,19 +2532,33 @@
         "node": "*"
       }
     },
-    "node_modules/@ember-data/request": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@ember-data/request/-/request-4.12.0.tgz",
-      "integrity": "sha512-n08NaFwJPq8TUj0F5M5Y88hZ8OhuzaeHjygnaumZtAnCbM9vRrJvrGCcTkfPp2XL3jfKOzeTHNzWzX8XY+efzQ==",
+    "node_modules/@ember-data/private-build-infra/node_modules/rsvp": {
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
+      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || >= 7.*"
+      }
+    },
+    "node_modules/@ember-data/record-data": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@ember-data/record-data/-/record-data-4.11.3.tgz",
+      "integrity": "sha512-8NmeEZJ7or354NLZJgibJ1FuhWL70H6G24tGSEIzM8IV7wr6TreIyaWODaW372QwamWYgFIpfnFwWt5MTlY/gw==",
       "dev": true,
       "dependencies": {
-        "@ember-data/private-build-infra": "4.12.0",
-        "@ember/test-waiters": "^3.0.2",
+        "@ember-data/canary-features": "4.11.3",
+        "@ember-data/private-build-infra": "4.11.3",
+        "@ember/edition-utils": "^1.2.0",
         "@embroider/macros": "^1.10.0",
+        "ember-auto-import": "^2.4.3",
         "ember-cli-babel": "^7.26.11"
       },
       "engines": {
-        "node": "16.* || >= 18"
+        "node": "^14.8.0 || 16.* || >= 18.*"
+      },
+      "peerDependencies": {
+        "@ember-data/store": "4.11.3"
       }
     },
     "node_modules/@ember-data/rfc395-data": {
@@ -2616,73 +2568,68 @@
       "dev": true
     },
     "node_modules/@ember-data/serializer": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@ember-data/serializer/-/serializer-4.12.0.tgz",
-      "integrity": "sha512-q6TJKrS95eFKm9fNm9UkwTQBJw5G+oj37lBPtsnLs6Sm05RCR8fvUX+WbkKi6CoqfKrn2zlZU8Z8mKg7DXc5nA==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@ember-data/serializer/-/serializer-4.11.3.tgz",
+      "integrity": "sha512-Qnzrowinz14/onQfwd4TPwNG0sMTAwTWE0RajYo2fysF3CKyAua0nIzmFtXKx0CogD7TYd0C5xf6nMjFesT09Q==",
       "dev": true,
       "dependencies": {
-        "@ember-data/private-build-infra": "4.12.0",
+        "@ember-data/private-build-infra": "4.11.3",
         "@embroider/macros": "^1.10.0",
+        "ember-auto-import": "^2.4.3",
         "ember-cli-babel": "^7.26.11",
         "ember-cli-test-info": "^1.0.0"
       },
       "engines": {
-        "node": "16.* || >= 18.*"
+        "node": "^14.8.0 || 16.* || >= 18.*"
       },
       "peerDependencies": {
-        "@ember-data/store": "4.12.0",
+        "@ember-data/store": "4.11.3",
         "@ember/string": "^3.0.1",
         "ember-inflector": "^4.0.2"
       }
     },
     "node_modules/@ember-data/store": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@ember-data/store/-/store-4.12.0.tgz",
-      "integrity": "sha512-7zOxg363f8raqmJcQYiH6JAWWyBDLRQTWLZeyeJD3kgFV+MqWlHLjEvOFCDW2SnfIrVAyFH7oh7x7POxClw9mA==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@ember-data/store/-/store-4.11.3.tgz",
+      "integrity": "sha512-ogwWy+VqMpkCGs4n30pzuB2vqv/dJRL6wdV3fdNKpXrDugffjuMPpLBQYF937qztDUZKxmnbWAZe5PbQOz8b1Q==",
       "dev": true,
       "dependencies": {
-        "@ember-data/private-build-infra": "4.12.0",
+        "@ember-data/canary-features": "4.11.3",
+        "@ember-data/private-build-infra": "4.11.3",
         "@embroider/macros": "^1.10.0",
+        "ember-auto-import": "^2.4.3",
         "ember-cached-decorator-polyfill": "^1.0.1",
         "ember-cli-babel": "^7.26.11"
       },
       "engines": {
-        "node": "16.* || >= 18.*"
+        "node": "^14.8.0 || 16.* || >= 18.*"
       },
       "peerDependencies": {
-        "@ember-data/graph": "4.12.0",
-        "@ember-data/json-api": "4.12.0",
-        "@ember-data/legacy-compat": "4.12.0",
-        "@ember-data/model": "4.12.0",
-        "@ember-data/tracking": "4.12.0",
+        "@ember-data/model": "4.11.3",
+        "@ember-data/record-data": "4.11.3",
+        "@ember-data/tracking": "4.11.3",
         "@ember/string": "^3.0.1",
         "@glimmer/tracking": "^1.1.2"
       },
       "peerDependenciesMeta": {
-        "@ember-data/graph": {
-          "optional": true
-        },
-        "@ember-data/json-api": {
-          "optional": true
-        },
-        "@ember-data/legacy-compat": {
-          "optional": true
-        },
         "@ember-data/model": {
+          "optional": true
+        },
+        "@ember-data/record-data": {
           "optional": true
         }
       }
     },
     "node_modules/@ember-data/tracking": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@ember-data/tracking/-/tracking-4.12.0.tgz",
-      "integrity": "sha512-Jgg6ayR70HLdMqIuXgh/5bdD93Qxop4evSA/f0ltDyilTQ63Olw6GkaYBpjOf6rZbRxdAOwLOOITyoE04zVq+g==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@ember-data/tracking/-/tracking-4.11.3.tgz",
+      "integrity": "sha512-YZxFTMe2TBL8H8/GrnrvP7Wc/uuAijoSyiP2g6TMNRsL1e/3BWDT0EIl+B/5Wji+dchofY8iuMWfpY7VDvPIzA==",
       "dev": true,
       "dependencies": {
         "ember-cli-babel": "^7.26.11"
       },
       "engines": {
-        "node": "16.* || >= 18"
+        "node": "14.* || 16.* || >= 18"
       }
     },
     "node_modules/@ember-decorators/utils": {
@@ -14518,32 +14465,29 @@
       }
     },
     "node_modules/ember-data": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/ember-data/-/ember-data-4.12.0.tgz",
-      "integrity": "sha512-E1A94HOurihoaFzJmArhtXfp56WsLlbTyhnqWfZKgqWZz1qKF4GVbDuOsGIsy6u345LdUCp2jtodRO2s43k88Q==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/ember-data/-/ember-data-4.11.3.tgz",
+      "integrity": "sha512-7vir6Re3M3M6yJoCHy6UxEg3oSY1JEnsuTByY3lJquWPaUamn7qbPQvNr16Tqh8EKrt+e/+X26czFm4kRGhpVg==",
       "dev": true,
       "dependencies": {
-        "@ember-data/adapter": "4.12.0",
-        "@ember-data/debug": "4.12.0",
-        "@ember-data/graph": "4.12.0",
-        "@ember-data/json-api": "4.12.0",
-        "@ember-data/legacy-compat": "4.12.0",
-        "@ember-data/model": "4.12.0",
-        "@ember-data/private-build-infra": "4.12.0",
-        "@ember-data/request": "4.12.0",
-        "@ember-data/serializer": "4.12.0",
-        "@ember-data/store": "4.12.0",
-        "@ember-data/tracking": "4.12.0",
+        "@ember-data/adapter": "4.11.3",
+        "@ember-data/debug": "4.11.3",
+        "@ember-data/model": "4.11.3",
+        "@ember-data/private-build-infra": "4.11.3",
+        "@ember-data/record-data": "4.11.3",
+        "@ember-data/serializer": "4.11.3",
+        "@ember-data/store": "4.11.3",
+        "@ember-data/tracking": "4.11.3",
         "@ember/edition-utils": "^1.2.0",
         "@embroider/macros": "^1.10.0",
         "@glimmer/env": "^0.1.7",
         "broccoli-merge-trees": "^4.2.0",
-        "ember-auto-import": "^2.6.1",
+        "ember-auto-import": "^2.4.3",
         "ember-cli-babel": "^7.26.11",
         "ember-inflector": "^4.0.2"
       },
       "engines": {
-        "node": "16.* || >= 18.*"
+        "node": "^14.8.0 || 16.* || >= 18.*"
       },
       "peerDependencies": {
         "@ember/string": "^3.0.1"
@@ -26032,40 +25976,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/path-scurry": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.9.2.tgz",
-      "integrity": "sha512-qSDLy2aGFPm8i4rsbHd4MNyTcrzHFsLQykrtbuGRknZZCBBVXSv2tSCDN2Cg6Rt/GFRw8GoW9y9Ecw5rIPG1sg==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^9.1.1",
-        "minipass": "^5.0.0 || ^6.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-9.1.2.tgz",
-      "integrity": "sha512-ERJq3FOzJTxBbFjZ7iDs+NiK4VI9Wz+RdrrAB8dio1oV+YvdPzUEE4QNiT2VD51DkIbCYRUUzCRkssXCHqSnKQ==",
-      "dev": true,
-      "engines": {
-        "node": "14 || >=16.14"
-      }
-    },
-    "node_modules/path-scurry/node_modules/minipass": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-6.0.2.tgz",
-      "integrity": "sha512-MzWSV5nYVT7mVyWCwn2o7JH13w2TBRmmSqSRCKzTw+lmft9X4z+3wjvs06Tzijo5z4W/kahUCDpRXTF+ZrmF/w==",
-      "dev": true,
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
     "node_modules/path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
@@ -35014,79 +34924,59 @@
       }
     },
     "@ember-data/adapter": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@ember-data/adapter/-/adapter-4.12.0.tgz",
-      "integrity": "sha512-sY7Zm73LSN1x1jO+lTV0+Vtdis6rBFAuRD3sln1BOW0y9che5WK+qyQs8FhjC6m9D/FFIKqUucWvaPO4/GazuQ==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@ember-data/adapter/-/adapter-4.11.3.tgz",
+      "integrity": "sha512-G7dbaPnYMW8VYxIT75KAkzax2mkWTs2TYxS7+qbphs6esXpO9Y/iNp5fTqLaACb9JqUypwEA/rlfC7/zkcGbBw==",
       "dev": true,
       "requires": {
-        "@ember-data/private-build-infra": "4.12.0",
+        "@ember-data/private-build-infra": "4.11.3",
+        "@ember/edition-utils": "^1.2.0",
         "@embroider/macros": "^1.10.0",
+        "ember-auto-import": "^2.4.3",
         "ember-cli-babel": "^7.26.11",
         "ember-cli-test-info": "^1.0.0"
       }
     },
+    "@ember-data/canary-features": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@ember-data/canary-features/-/canary-features-4.11.3.tgz",
+      "integrity": "sha512-RTLY2N9t1SXr4e90VBKi+3PIitwjTMBU8BcEhnKovT//sGlywohHq7T36H6nJuITRtki3On9PpbJOhhQZuyAlQ==",
+      "dev": true,
+      "requires": {
+        "@embroider/macros": "^1.10.0",
+        "ember-cli-babel": "^7.26.11"
+      }
+    },
     "@ember-data/debug": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@ember-data/debug/-/debug-4.12.0.tgz",
-      "integrity": "sha512-6SNJjoV3zKnjjZEu9/tOjeWdN70mxmkvHd+0Y7kjasmjLBgIkZk20+B/nFm25MpmmpfZEsvdUY3HIfu+iPy+5A==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@ember-data/debug/-/debug-4.11.3.tgz",
+      "integrity": "sha512-3pA5u3qy+pjtwcoyMzs7WijRrSQz5z+Vgn9b5Y4cEOHn8loS9riLCMScnFaQT3HjxQgq+3NkNb52sJafHPzs4Q==",
       "dev": true,
       "requires": {
-        "@ember-data/private-build-infra": "4.12.0",
+        "@ember-data/private-build-infra": "4.11.3",
         "@ember/edition-utils": "^1.2.0",
         "@embroider/macros": "^1.10.0",
-        "ember-auto-import": "^2.6.1",
-        "ember-cli-babel": "^7.26.11"
-      }
-    },
-    "@ember-data/graph": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@ember-data/graph/-/graph-4.12.0.tgz",
-      "integrity": "sha512-5crSekONC8cm/sPS4OnNNG1TrnCb4rqrM72Ux8i8xlomYpLq75R2gY4ibY1HRNstrEoAB09rzONTB0bRJHlTQw==",
-      "dev": true,
-      "requires": {
-        "@ember-data/private-build-infra": "4.12.0",
-        "@ember/edition-utils": "^1.2.0",
-        "@embroider/macros": "^1.10.0",
-        "ember-cli-babel": "^7.26.11"
-      }
-    },
-    "@ember-data/json-api": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@ember-data/json-api/-/json-api-4.12.0.tgz",
-      "integrity": "sha512-vtxuB7akuSfsEBvLX/8h4zGyIozynyq5Bf9I02ftIoIIwD21wN+g/ZG91KU6sNZzyeycTZEKpoYaITM84pLTTg==",
-      "dev": true,
-      "requires": {
-        "@ember-data/private-build-infra": "4.12.0",
-        "@ember/edition-utils": "^1.2.0",
-        "@embroider/macros": "^1.10.0",
-        "ember-cli-babel": "^7.26.11"
-      }
-    },
-    "@ember-data/legacy-compat": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@ember-data/legacy-compat/-/legacy-compat-4.12.0.tgz",
-      "integrity": "sha512-QVZczGMbTk8Ch+xiZt7KQk5UX2AdUsVdR3rSB/pJVZrWcUWo6ToAR2mPl97/cWd6VYFXBZgMamsxkeBO4q5HXA==",
-      "dev": true,
-      "requires": {
-        "@ember-data/private-build-infra": "4.12.0",
-        "@embroider/macros": "^1.10.0",
+        "ember-auto-import": "^2.4.3",
         "ember-cli-babel": "^7.26.11"
       }
     },
     "@ember-data/model": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@ember-data/model/-/model-4.12.0.tgz",
-      "integrity": "sha512-gE9LRmUkrJy9hJ+WeNns/GOMQC311R18SOvbsIVk5z/u2tgD5l0BjLSeqCaG/CjO+fCRsM8Ne/Ivm07c/CyezQ==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@ember-data/model/-/model-4.11.3.tgz",
+      "integrity": "sha512-nkDru5TZmOp4J1xp65D1bR3hBJ3u5KhKKfDpWeGnHW2YDCVUdLORRwW7vfrPnnXDIoJij42DwDVCiTY25Xhrqw==",
       "dev": true,
       "requires": {
-        "@ember-data/private-build-infra": "4.12.0",
+        "@ember-data/canary-features": "4.11.3",
+        "@ember-data/private-build-infra": "4.11.3",
         "@ember/edition-utils": "^1.2.0",
         "@embroider/macros": "^1.10.0",
+        "ember-auto-import": "^2.4.3",
         "ember-cached-decorator-polyfill": "^1.0.1",
         "ember-cli-babel": "^7.26.11",
         "ember-cli-string-utils": "^1.1.0",
         "ember-cli-test-info": "^1.0.0",
-        "inflection": "~2.0.1"
+        "ember-compatibility-helpers": "^1.2.6",
+        "inflection": "~2.0.0"
       },
       "dependencies": {
         "inflection": {
@@ -35098,14 +34988,15 @@
       }
     },
     "@ember-data/private-build-infra": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@ember-data/private-build-infra/-/private-build-infra-4.12.0.tgz",
-      "integrity": "sha512-cBuEZhxV8uyIRr+9oUZ4smQb+6p6ryH89+WdrGMTeKgKP3XkdlK9w+6veQAYOqgWAulTwmAxX+YU/zoPq2ne7w==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@ember-data/private-build-infra/-/private-build-infra-4.11.3.tgz",
+      "integrity": "sha512-bXFQMEegUc+vKn/vD7FmAkq7ECE0okZ2sbtv/0RXqYn7TLk44rvGzpqSUXUowpCaGI/87MmaW8JaZMMdqF9wuw==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.21.4",
-        "@babel/plugin-transform-block-scoping": "^7.21.0",
-        "@babel/runtime": "^7.21.0",
+        "@babel/core": "^7.20.2",
+        "@babel/plugin-transform-block-scoping": "^7.20.2",
+        "@babel/runtime": "^7.20.1",
+        "@ember-data/canary-features": "4.11.3",
         "@ember/edition-utils": "^1.2.0",
         "@embroider/macros": "^1.10.0",
         "babel-import-util": "^1.3.0",
@@ -35124,8 +35015,10 @@
         "ember-cli-string-utils": "^1.1.0",
         "ember-cli-version-checker": "^5.1.2",
         "git-repo-info": "^2.1.1",
-        "glob": "^9.3.4",
+        "glob": "^8.0.3",
         "npm-git-info": "^1.0.3",
+        "rimraf": "^3.0.2",
+        "rsvp": "^4.8.5",
         "semver": "^7.3.8",
         "silent-error": "^1.1.1"
       },
@@ -35165,31 +35058,26 @@
           }
         },
         "glob": {
-          "version": "9.3.5",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
-          "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+          "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
-            "minimatch": "^8.0.2",
-            "minipass": "^4.2.4",
-            "path-scurry": "^1.6.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^5.0.1",
+            "once": "^1.3.0"
           }
         },
         "minimatch": {
-          "version": "8.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
-          "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+          "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
           "dev": true,
           "requires": {
             "brace-expansion": "^2.0.1"
           }
-        },
-        "minipass": {
-          "version": "4.2.8",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
-          "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
-          "dev": true
         },
         "promise-map-series": {
           "version": "0.3.0",
@@ -35240,18 +35128,26 @@
               }
             }
           }
+        },
+        "rsvp": {
+          "version": "4.8.5",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
+          "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
+          "dev": true
         }
       }
     },
-    "@ember-data/request": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@ember-data/request/-/request-4.12.0.tgz",
-      "integrity": "sha512-n08NaFwJPq8TUj0F5M5Y88hZ8OhuzaeHjygnaumZtAnCbM9vRrJvrGCcTkfPp2XL3jfKOzeTHNzWzX8XY+efzQ==",
+    "@ember-data/record-data": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@ember-data/record-data/-/record-data-4.11.3.tgz",
+      "integrity": "sha512-8NmeEZJ7or354NLZJgibJ1FuhWL70H6G24tGSEIzM8IV7wr6TreIyaWODaW372QwamWYgFIpfnFwWt5MTlY/gw==",
       "dev": true,
       "requires": {
-        "@ember-data/private-build-infra": "4.12.0",
-        "@ember/test-waiters": "^3.0.2",
+        "@ember-data/canary-features": "4.11.3",
+        "@ember-data/private-build-infra": "4.11.3",
+        "@ember/edition-utils": "^1.2.0",
         "@embroider/macros": "^1.10.0",
+        "ember-auto-import": "^2.4.3",
         "ember-cli-babel": "^7.26.11"
       }
     },
@@ -35262,33 +35158,36 @@
       "dev": true
     },
     "@ember-data/serializer": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@ember-data/serializer/-/serializer-4.12.0.tgz",
-      "integrity": "sha512-q6TJKrS95eFKm9fNm9UkwTQBJw5G+oj37lBPtsnLs6Sm05RCR8fvUX+WbkKi6CoqfKrn2zlZU8Z8mKg7DXc5nA==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@ember-data/serializer/-/serializer-4.11.3.tgz",
+      "integrity": "sha512-Qnzrowinz14/onQfwd4TPwNG0sMTAwTWE0RajYo2fysF3CKyAua0nIzmFtXKx0CogD7TYd0C5xf6nMjFesT09Q==",
       "dev": true,
       "requires": {
-        "@ember-data/private-build-infra": "4.12.0",
+        "@ember-data/private-build-infra": "4.11.3",
         "@embroider/macros": "^1.10.0",
+        "ember-auto-import": "^2.4.3",
         "ember-cli-babel": "^7.26.11",
         "ember-cli-test-info": "^1.0.0"
       }
     },
     "@ember-data/store": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@ember-data/store/-/store-4.12.0.tgz",
-      "integrity": "sha512-7zOxg363f8raqmJcQYiH6JAWWyBDLRQTWLZeyeJD3kgFV+MqWlHLjEvOFCDW2SnfIrVAyFH7oh7x7POxClw9mA==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@ember-data/store/-/store-4.11.3.tgz",
+      "integrity": "sha512-ogwWy+VqMpkCGs4n30pzuB2vqv/dJRL6wdV3fdNKpXrDugffjuMPpLBQYF937qztDUZKxmnbWAZe5PbQOz8b1Q==",
       "dev": true,
       "requires": {
-        "@ember-data/private-build-infra": "4.12.0",
+        "@ember-data/canary-features": "4.11.3",
+        "@ember-data/private-build-infra": "4.11.3",
         "@embroider/macros": "^1.10.0",
+        "ember-auto-import": "^2.4.3",
         "ember-cached-decorator-polyfill": "^1.0.1",
         "ember-cli-babel": "^7.26.11"
       }
     },
     "@ember-data/tracking": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@ember-data/tracking/-/tracking-4.12.0.tgz",
-      "integrity": "sha512-Jgg6ayR70HLdMqIuXgh/5bdD93Qxop4evSA/f0ltDyilTQ63Olw6GkaYBpjOf6rZbRxdAOwLOOITyoE04zVq+g==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@ember-data/tracking/-/tracking-4.11.3.tgz",
+      "integrity": "sha512-YZxFTMe2TBL8H8/GrnrvP7Wc/uuAijoSyiP2g6TMNRsL1e/3BWDT0EIl+B/5Wji+dchofY8iuMWfpY7VDvPIzA==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.11"
@@ -44941,27 +44840,24 @@
       }
     },
     "ember-data": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/ember-data/-/ember-data-4.12.0.tgz",
-      "integrity": "sha512-E1A94HOurihoaFzJmArhtXfp56WsLlbTyhnqWfZKgqWZz1qKF4GVbDuOsGIsy6u345LdUCp2jtodRO2s43k88Q==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/ember-data/-/ember-data-4.11.3.tgz",
+      "integrity": "sha512-7vir6Re3M3M6yJoCHy6UxEg3oSY1JEnsuTByY3lJquWPaUamn7qbPQvNr16Tqh8EKrt+e/+X26czFm4kRGhpVg==",
       "dev": true,
       "requires": {
-        "@ember-data/adapter": "4.12.0",
-        "@ember-data/debug": "4.12.0",
-        "@ember-data/graph": "4.12.0",
-        "@ember-data/json-api": "4.12.0",
-        "@ember-data/legacy-compat": "4.12.0",
-        "@ember-data/model": "4.12.0",
-        "@ember-data/private-build-infra": "4.12.0",
-        "@ember-data/request": "4.12.0",
-        "@ember-data/serializer": "4.12.0",
-        "@ember-data/store": "4.12.0",
-        "@ember-data/tracking": "4.12.0",
+        "@ember-data/adapter": "4.11.3",
+        "@ember-data/debug": "4.11.3",
+        "@ember-data/model": "4.11.3",
+        "@ember-data/private-build-infra": "4.11.3",
+        "@ember-data/record-data": "4.11.3",
+        "@ember-data/serializer": "4.11.3",
+        "@ember-data/store": "4.11.3",
+        "@ember-data/tracking": "4.11.3",
         "@ember/edition-utils": "^1.2.0",
         "@embroider/macros": "^1.10.0",
         "@glimmer/env": "^0.1.7",
         "broccoli-merge-trees": "^4.2.0",
-        "ember-auto-import": "^2.6.1",
+        "ember-auto-import": "^2.4.3",
         "ember-cli-babel": "^7.26.11",
         "ember-inflector": "^4.0.2"
       },
@@ -53970,30 +53866,6 @@
       "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
       "integrity": "sha512-4GlJ6rZDhQZFE0DPVKh0e9jmZ5egZfxTkp7bcRDuPlJXbAwhxcl2dINPUAsjLdejqaLsCeg8axcLjIbvBjN4pQ==",
       "dev": true
-    },
-    "path-scurry": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.9.2.tgz",
-      "integrity": "sha512-qSDLy2aGFPm8i4rsbHd4MNyTcrzHFsLQykrtbuGRknZZCBBVXSv2tSCDN2Cg6Rt/GFRw8GoW9y9Ecw5rIPG1sg==",
-      "dev": true,
-      "requires": {
-        "lru-cache": "^9.1.1",
-        "minipass": "^5.0.0 || ^6.0.2"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "9.1.2",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-9.1.2.tgz",
-          "integrity": "sha512-ERJq3FOzJTxBbFjZ7iDs+NiK4VI9Wz+RdrrAB8dio1oV+YvdPzUEE4QNiT2VD51DkIbCYRUUzCRkssXCHqSnKQ==",
-          "dev": true
-        },
-        "minipass": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-6.0.2.tgz",
-          "integrity": "sha512-MzWSV5nYVT7mVyWCwn2o7JH13w2TBRmmSqSRCKzTw+lmft9X4z+3wjvs06Tzijo5z4W/kahUCDpRXTF+ZrmF/w==",
-          "dev": true
-        }
-      }
     },
     "path-to-regexp": {
       "version": "0.1.7",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.2",
     "ember-concurrency": "^2.3.7",
-    "ember-data": "~4.12.0",
+    "ember-data": "~4.11.0",
     "ember-fetch": "^8.1.2",
     "ember-load-initializers": "^2.1.2",
     "ember-modifier": "^3.2.0",


### PR DESCRIPTION
v4.12.0 includes a relationship promise caching bug which causes the wrong data to be loaded. This has the side affect that we try to load the submission form with the wrong id which causes the app to break.

Downgrading to v4.11 fixes the issue for now. Once the bug is fixed we can update to 4.12 again.