### PR TITLE
Bump ember-submission-form-fields v2.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@glimmer/tracking": "^1.1.2",
         "@lblod/ember-acmidm-login": "^1.0.0",
         "@lblod/ember-mock-login": "^0.7.0",
-        "@lblod/ember-submission-form-fields": "^2.6.1",
+        "@lblod/ember-submission-form-fields": "^2.11.0",
         "broccoli-asset-rev": "^3.0.0",
         "concurrently": "^8.0.1",
         "ember-auto-import": "^2.6.3",
@@ -3777,9 +3777,9 @@
       }
     },
     "node_modules/@lblod/ember-submission-form-fields": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-submission-form-fields/-/ember-submission-form-fields-2.10.0.tgz",
-      "integrity": "sha512-fQFrwDxHADZvsgW6w6+xXFjrEgw8J3HuSkoayE0srWxuDmGYTPGRMWCFkTqL4tcC55EoYHaidR1muzrKPs+cbA==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-submission-form-fields/-/ember-submission-form-fields-2.11.0.tgz",
+      "integrity": "sha512-EAvrSMRHw6PuLreWyARddFDu2nE/nfxzk8qghHce4HM5+wYekXPSZ4Y+cuhALgZEolQXXl6/fw1pDxZS4Hco9g==",
       "dev": true,
       "dependencies": {
         "@lblod/submission-form-helpers": "^2.0.1",
@@ -36163,9 +36163,9 @@
       }
     },
     "@lblod/ember-submission-form-fields": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-submission-form-fields/-/ember-submission-form-fields-2.10.0.tgz",
-      "integrity": "sha512-fQFrwDxHADZvsgW6w6+xXFjrEgw8J3HuSkoayE0srWxuDmGYTPGRMWCFkTqL4tcC55EoYHaidR1muzrKPs+cbA==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-submission-form-fields/-/ember-submission-form-fields-2.11.0.tgz",
+      "integrity": "sha512-EAvrSMRHw6PuLreWyARddFDu2nE/nfxzk8qghHce4HM5+wYekXPSZ4Y+cuhALgZEolQXXl6/fw1pDxZS4Hco9g==",
       "dev": true,
       "requires": {
         "@lblod/submission-form-helpers": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@glimmer/tracking": "^1.1.2",
     "@lblod/ember-acmidm-login": "^1.0.0",
     "@lblod/ember-mock-login": "^0.7.0",
-    "@lblod/ember-submission-form-fields": "^2.6.1",
+    "@lblod/ember-submission-form-fields": "^2.11.0",
     "broccoli-asset-rev": "^3.0.0",
     "concurrently": "^8.0.1",
     "ember-auto-import": "^2.6.3",


### PR DESCRIPTION
# Description
DL-5180

This PR is about updating `ember-submission-form-fields` to v2.11.0 to use the new alert field in the Besluit handhaven na ontvangst schorsingsbesluit (besluit handhaven) form.

- Bumping `ember-submission-form-fields` to v2.11.0

See feature -> https://github.com/lblod/ember-submission-form-fields/commit/3ed7941cb2ac392e866de8d593d965bdedaf6210


# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

# Related module

- https://github.com/lblod/ember-submission-form-fields

# Notes

**Bump frontend**
