### PR TITLE
Register the custom form fields earlier

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,5 +1,8 @@
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
+import { registerFormField as registerDecisionArticlesField } from 'frontend-toezicht-abb/components/submissions/fields/decision-articles-field';
+import { registerFormField as registerDecisionDocumentsField } from 'frontend-toezicht-abb/components/submissions/fields/decision-documents-field';
+import { registerFormField as registerDecisionRemoteDocumentsField } from 'frontend-toezicht-abb/components/submissions/fields/decision-remote-documents';
 
 export default class ApplicationRoute extends Route {
   @service currentSession;
@@ -8,6 +11,7 @@ export default class ApplicationRoute extends Route {
   async beforeModel() {
     await this.session.setup();
     await this._loadCurrentSession();
+    this.registerFormFields();
   }
 
   async _loadCurrentSession() {
@@ -16,5 +20,11 @@ export default class ApplicationRoute extends Route {
     } catch (error) {
       this.session.invalidate();
     }
+  }
+
+  registerFormFields() {
+    registerDecisionArticlesField();
+    registerDecisionDocumentsField();
+    registerDecisionRemoteDocumentsField();
   }
 }

--- a/app/routes/supervision/submissions/show.js
+++ b/app/routes/supervision/submissions/show.js
@@ -1,19 +1,8 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
-import { registerFormField } from 'frontend-toezicht-abb/components/submissions/fields/decision-articles-field';
-import { registerFormField as registerDecisionDocumentsField } from 'frontend-toezicht-abb/components/submissions/fields/decision-documents-field';
-import { registerFormField as registerDecisionRemoteDocumentsField } from 'frontend-toezicht-abb/components/submissions/fields/decision-remote-documents';
 
 export default class SupervisionSubmissionsShowRoute extends Route {
   @service store;
-
-  constructor() {
-    super(...arguments);
-
-    registerFormField();
-    registerDecisionDocumentsField();
-    registerDecisionRemoteDocumentsField();
-  }
 
   model(params) {
     return this.store.findRecord('submission', params.id, {


### PR DESCRIPTION
We're using these fields in multiple routes but were only registering it in one so we were still using the old field in the other route, which depends on a different backend configuration. We now register these fields earlier so they work as expected.