### PR TITLE
Dl 7363 fix download special characters

### DIFF
--- a/app/components/submissions/fields/decision-remote-documents.gjs
+++ b/app/components/submissions/fields/decision-remote-documents.gjs
@@ -502,7 +502,7 @@ export default class DecisionRemoteDocumentsShowComponent extends Component {
             `Something went wrong while trying to download '${downloadLink(rdo)}': ${response.status} ${response.statusText}`,
           );
         }
-        return response;
+        return { input: response, name: rdo.file.filename };
       });
     });
 

--- a/app/models/file.js
+++ b/app/models/file.js
@@ -22,6 +22,6 @@ export default class File extends Model {
   }
 
   get downloadLink() {
-    return `/files/${this.id}/download?name=${this.filename}`;
+    return `/files/${this.id}/download?name=${encodeURIComponent(this.filename)}`;
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@glimmer/tracking": "^1.1.2",
         "@lblod/ember-acmidm-login": "^2.2.0",
         "@lblod/ember-mock-login": "^0.12.0",
-        "@lblod/ember-submission-form-fields": "^3.4.0",
+        "@lblod/ember-submission-form-fields": "^3.6.1",
         "@lblod/submission-form-helpers": "^3.0.0",
         "@warp-drive/build-config": "^0.0.1",
         "broccoli-asset-rev": "^3.0.0",
@@ -6535,19 +6535,21 @@
       }
     },
     "node_modules/@lblod/ember-submission-form-fields": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-submission-form-fields/-/ember-submission-form-fields-3.5.0.tgz",
-      "integrity": "sha512-4iwJ1ITwcG4vZku1gFL4wbKy3wRJ1siOQjSM95sEKwltPCk+xlvGtBgfsqsyx4DlAYkoo12y1OGeb6ob9sRbeg==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-submission-form-fields/-/ember-submission-form-fields-3.6.1.tgz",
+      "integrity": "sha512-jXf339upMJVMyF1W1hvIbe3iOXWmC5NBJhPIQIp5Ay7kIj7/+2pc52bL3i55Q7fhXb361vAdalYbOQUk5KYDLQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/core": "7.26.0",
+        "@embroider/macros": "^1.20.2",
         "client-zip": "^2.4.4",
         "clipboardy": "^4.0.0",
         "ember-auto-import": "^2.8.1",
         "ember-cli-babel": "^8.2.0",
         "ember-cli-htmlbars": "^6.3.0",
         "ember-cli-version-checker": "^5.1.2",
-        "ember-concurrency": "^4.0.2",
+        "ember-concurrency": "^4.0.2 || ^5.0.0",
         "ember-modifier": "^4.1.0",
         "ember-truth-helpers": "^4.0.0 || ^5.0.0",
         "forking-store": "^2.0.0",
@@ -6594,6 +6596,95 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@lblod/ember-submission-form-fields/node_modules/@embroider/macros": {
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-1.20.5.tgz",
+      "integrity": "sha512-JjIynmob1HbOwVG5uvwrOWecf48Vf9dltKL5C9x5Q6gEoLZJln6iG8D9YBM9EO24Oi8Ftw+oS7IJjA7TFvMLCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@embroider/shared-internals": "3.1.1",
+        "assert-never": "^1.2.1",
+        "babel-import-util": "^3.0.1",
+        "ember-cli-babel": "^7.26.6 || ^8.3.1",
+        "find-up": "^5.0.0",
+        "lodash": "^4.17.21",
+        "resolve": "^1.20.0",
+        "semver": "^7.3.2"
+      },
+      "engines": {
+        "node": "12.* || 14.* || >= 16"
+      },
+      "peerDependencies": {
+        "@glint/template": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@glint/template": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@lblod/ember-submission-form-fields/node_modules/@embroider/macros/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@lblod/ember-submission-form-fields/node_modules/@embroider/shared-internals": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-3.1.1.tgz",
+      "integrity": "sha512-IlxD8okTt9cRUFpJKD8gTuQUBuEflrhCUju1xZFdYvmGm5XVqHPfG4I6+bEdKb8NO92aqHxr9SYuYibDmpMM9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-import-util": "^3.0.1",
+        "debug": "^4.3.2",
+        "ember-rfc176-data": "^0.3.17",
+        "fs-extra": "^9.1.0",
+        "is-subdir": "^1.2.0",
+        "js-string-escape": "^1.0.1",
+        "lodash": "^4.17.21",
+        "minimatch": "^3.0.4",
+        "pkg-entry-points": "^1.1.1",
+        "resolve-package-path": "^4.0.1",
+        "resolve.exports": "^2.0.2",
+        "semver": "^7.3.5",
+        "typescript-memoize": "^1.0.1"
+      },
+      "engines": {
+        "node": "12.* || 14.* || >= 16"
+      }
+    },
+    "node_modules/@lblod/ember-submission-form-fields/node_modules/@embroider/shared-internals/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@lblod/ember-submission-form-fields/node_modules/babel-import-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/babel-import-util/-/babel-import-util-3.0.1.tgz",
+      "integrity": "sha512-2copPaWQFUrzooJVIVZA/Oppx/S/KOoZ4Uhr+XWEQDMZ8Rvq/0SNQpbdIyMBJ8IELWt10dewuJw+tX4XjOo7Rg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.*"
       }
     },
     "node_modules/@lblod/submission-form-helpers": {
@@ -14791,19 +14882,19 @@
       }
     },
     "node_modules/ember-cli-babel": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-8.2.0.tgz",
-      "integrity": "sha512-8H4+jQElCDo6tA7CamksE66NqBXWs7VNpS3a738L9pZCjg2kXIX4zoyHzkORUqCtr0Au7YsCnrlAMi1v2ALo7A==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-8.3.1.tgz",
+      "integrity": "sha512-Pxm5JP0jQ6fCBlXuh1BFmhrg2/5YXjhf16JI/n8ReOR6Nl+fEbudMpdO69LlqZRsMmTgdjCRmfSxMh26Wsw/rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.20.7",
-        "@babel/plugin-proposal-class-properties": "^7.16.5",
         "@babel/plugin-proposal-decorators": "^7.20.13",
-        "@babel/plugin-proposal-private-methods": "^7.16.5",
-        "@babel/plugin-proposal-private-property-in-object": "^7.20.5",
+        "@babel/plugin-transform-class-properties": "^7.16.5",
         "@babel/plugin-transform-class-static-block": "^7.22.11",
         "@babel/plugin-transform-modules-amd": "^7.20.11",
+        "@babel/plugin-transform-private-methods": "^7.16.5",
+        "@babel/plugin-transform-private-property-in-object": "^7.20.5",
         "@babel/plugin-transform-runtime": "^7.13.9",
         "@babel/plugin-transform-typescript": "^7.20.13",
         "@babel/preset-env": "^7.20.2",
@@ -14840,26 +14931,6 @@
       "license": "MIT",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/ember-cli-babel/node_modules/@babel/plugin-proposal-private-property-in-object": {
-      "version": "7.21.11",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz",
-      "integrity": "sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==",
-      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-property-in-object instead.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.18.6",
-        "@babel/helper-create-class-features-plugin": "^7.21.0",
-        "@babel/helper-plugin-utils": "^7.20.2",
-        "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/ember-cli-babel/node_modules/@babel/runtime": {
@@ -31814,6 +31885,16 @@
       "deprecated": "https://github.com/lydell/resolve-url#deprecated",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/resolve.exports": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
+      "integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/responselike": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@glimmer/tracking": "^1.1.2",
     "@lblod/ember-acmidm-login": "^2.2.0",
     "@lblod/ember-mock-login": "^0.12.0",
-    "@lblod/ember-submission-form-fields": "^3.4.0",
+    "@lblod/ember-submission-form-fields": "^3.6.1",
     "@lblod/submission-form-helpers": "^3.0.0",
     "@warp-drive/build-config": "^0.0.1",
     "broccoli-asset-rev": "^3.0.0",


### PR DESCRIPTION
[DL-7363]

Fix to allow files containing special characters in their titels (E.g. ^) to be downloaded as a file and in zip.

TO TEST:
- proxy to dev
- check if you can download the files from submission 6A01C1BACCE83E13DB58FC1C (seperate/zip)